### PR TITLE
Balancing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # ppdp
 
-TCP Proxy (relay) server with Support Proxy Protocol and TCPDump like function
+TCP Proxy (relay) server with Dynamic upstream resolution, Some balancing algorism, Support Proxy Protocol and TCPDump like function
 
 ```
+% ./ppdp -h
 Usage:
   ppdp [OPTIONS]
 
 Application Options:
-  -v, --version                Show version
-  -l, --listen=                address to bind (default: 0.0.0.0:3000)
-      --upstream=              upstream server: upstream-server:port
-      --proxy-connect-timeout= timeout of connection to upstream (default: 60s)
-      --proxy-protocol         use proxy-proto for listen
-      --dump-tcp=              Dump TCP. 0 = disable, 1 = src to dest, 2 = both (default: 0)
+  -v, --version                                       Show version
+  -l, --listen=                                       address to bind (default: 0.0.0.0:3000)
+      --upstream=                                     upstream server: upstream-server:port
+      --proxy-connect-timeout=                        timeout of connection to upstream (default: 60s)
+      --proxy-protocol                                use proxy-proto for listen
+      --dump-tcp=                                     Dump TCP. 0 = disable, 1 = src to dest, 2 = both (default: 0)
+      --dump-mysql-ping                               Dump mysql ping packet
+      --max-connect-retry=                            number of max connection retry (default: 3)
+      --balancing=[leastconn|iphash|fixed|remotehash] balancing mode connection to upstream. iphash: remote ip based, remotehash: remote ip + port based, fixed:
+                                                      upstream host based (default: leastconn)
 
 Help Options:
-  -h, --help                   Show this help message
+  -h, --help                                          Show this help message
  ```
 
 Sample

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.14
 
 require (
 	github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507
+	github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lestrrat-go/server-starter v0.0.0-20200204225643-53093363107d
 	github.com/pkg/errors v0.9.1
+	github.com/stathat/consistent v1.0.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	stathat.com/c/consistent v1.0.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507
-	github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lestrrat-go/server-starter v0.0.0-20200204225643-53093363107d
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507 h1:dmVRVC/MmuwC2edm/P6oWIP+9n+p9IgVgK0lq9mBQjU=
 github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
-github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
-github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507 h1:dmVRVC/MmuwC2edm/P6oWIP+9n+p9IgVgK0lq9mBQjU=
 github.com/armon/go-proxyproto v0.0.0-20200108142055-f0b8253b1507/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
+github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
+github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,6 +24,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/stathat/consistent v1.0.0 h1:ZFJ1QTRn8npNBKW065raSZ8xfOqhpb8vLOkfp4CcL/U=
+github.com/stathat/consistent v1.0.0/go.mod h1:uajTPbgSygZBJ+V+0mY7meZ8i0XAcZs7AQ6V121XSxw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -62,3 +66,5 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
+stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=

--- a/ppdp.go
+++ b/ppdp.go
@@ -32,6 +32,7 @@ type cmdOpts struct {
 	ProxyProtocol       bool          `long:"proxy-protocol" description:"use proxy-proto for listen"`
 	DumpTCP             uint64        `long:"dump-tcp" default:"0" description:"Dump TCP. 0 = disable, 1 = src to dest, 2 = both"`
 	DumpMySQLPing       bool          `long:"dump-mysql-ping" description:"Dump mysql ping packet"`
+	BalancingMode       string        `long:"balancing" default:"leastconn" description:"balancing mode connection to upstream. " choice:"leastconn" choice:"iphash" choice:"fixed"`
 }
 
 func printVersion() {
@@ -103,7 +104,7 @@ func main() {
 			l = &proxyproto.Listener{Listener: l}
 		}
 		eg.Go(func() error {
-			p := proxy.New(l, u, opts.ProxyConnectTimeout, opts.DumpTCP, opts.DumpMySQLPing, logger)
+			p := proxy.New(l, u, opts.ProxyConnectTimeout, opts.DumpTCP, opts.DumpMySQLPing, opts.MaxConnectRerty, logger)
 			err := p.Start(ctx)
 			if err != nil {
 				cancel()

--- a/ppdp.go
+++ b/ppdp.go
@@ -32,6 +32,7 @@ type cmdOpts struct {
 	ProxyProtocol       bool          `long:"proxy-protocol" description:"use proxy-proto for listen"`
 	DumpTCP             uint64        `long:"dump-tcp" default:"0" description:"Dump TCP. 0 = disable, 1 = src to dest, 2 = both"`
 	DumpMySQLPing       bool          `long:"dump-mysql-ping" description:"Dump mysql ping packet"`
+	MaxConnectRerty     int           `long:"max-connect-retry" default:"3" description:"number of max connection retry"`
 	BalancingMode       string        `long:"balancing" default:"leastconn" description:"balancing mode connection to upstream. " choice:"leastconn" choice:"iphash" choice:"fixed"`
 }
 
@@ -59,7 +60,7 @@ func main() {
 
 	logger, _ := zap.NewProduction()
 
-	u, err := upstream.New(opts.Upstream, logger)
+	u, err := upstream.New(opts.Upstream, opts.BalancingMode, logger)
 	if err != nil {
 		logger.Fatal("failed initialize upstream", zap.Error(err))
 	}

--- a/ppdp.go
+++ b/ppdp.go
@@ -33,7 +33,7 @@ type cmdOpts struct {
 	DumpTCP             uint64        `long:"dump-tcp" default:"0" description:"Dump TCP. 0 = disable, 1 = src to dest, 2 = both"`
 	DumpMySQLPing       bool          `long:"dump-mysql-ping" description:"Dump mysql ping packet"`
 	MaxConnectRerty     int           `long:"max-connect-retry" default:"3" description:"number of max connection retry"`
-	BalancingMode       string        `long:"balancing" default:"leastconn" description:"balancing mode connection to upstream. " choice:"leastconn" choice:"iphash" choice:"fixed"`
+	BalancingMode       string        `long:"balancing" default:"leastconn" description:"balancing mode connection to upstream. iphash: remote ip based, remotehash: remote ip + port based, fixed: upstream host based" choice:"leastconn" choice:"iphash" choice:"fixed" choice:"remotehash"`
 }
 
 func printVersion() {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -28,10 +28,11 @@ type Proxy struct {
 	logger   *zap.Logger
 	dumpTCP  uint64
 	dumpPing bool
+	maxRetry int
 }
 
 // New create new proxy
-func New(l net.Listener, u *upstream.Upstream, t time.Duration, dumpTCP uint64, dumpPing bool, logger *zap.Logger) *Proxy {
+func New(l net.Listener, u *upstream.Upstream, t time.Duration, dumpTCP uint64, dumpPing bool, maxRetry int, logger *zap.Logger) *Proxy {
 	return &Proxy{
 		listener: l,
 		upstream: u,
@@ -40,6 +41,7 @@ func New(l net.Listener, u *upstream.Upstream, t time.Duration, dumpTCP uint64, 
 		logger:   logger,
 		dumpTCP:  dumpTCP,
 		dumpPing: dumpPing,
+		maxRetry: maxRetry,
 	}
 }
 
@@ -104,7 +106,7 @@ func (p *Proxy) handleConn(c net.Conn) error {
 
 	logger.Info("log", zap.String("status", "Connected"))
 
-	ips, err := p.upstream.GetAll()
+	ips, err := p.upstream.GetN(p.maxRetry)
 	if err != nil {
 		logger.Error("Failed to get upstream", zap.Error(err))
 		c.Close()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -106,7 +106,7 @@ func (p *Proxy) handleConn(c net.Conn) error {
 
 	logger.Info("log", zap.String("status", "Connected"))
 
-	ips, err := p.upstream.GetN(p.maxRetry)
+	ips, err := p.upstream.GetN(p.maxRetry, c.RemoteAddr())
 	if err != nil {
 		logger.Error("Failed to get upstream", zap.Error(err))
 		c.Close()
@@ -114,7 +114,7 @@ func (p *Proxy) handleConn(c net.Conn) error {
 	}
 
 	var s net.Conn
-	var ip *upstream.IP
+	var ip upstream.IP
 	for _, ip = range ips {
 		s, err = net.DialTimeout("tcp", ip.Address, p.timeout)
 		if err == nil {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -10,17 +10,20 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stathat/consistent"
 	"go.uber.org/zap"
 )
 
 // Upstream struct
 type Upstream struct {
-	port   string
-	host   string
-	ips    []*IP
-	csum   string
-	logger *zap.Logger
-	mu     sync.Mutex
+	port       string
+	host       string
+	ips        []IP
+	csum       string
+	consistent *consistent.Consistent
+	balancing  string
+	logger     *zap.Logger
+	mu         sync.Mutex
 	// current resolved record version
 	version uint64
 	cancel  context.CancelFunc
@@ -35,8 +38,13 @@ type IP struct {
 	version uint64
 }
 
+// String :
+func (ip IP) String() string {
+	return ip.Address
+}
+
 // New :
-func New(upstream string, logger *zap.Logger) (*Upstream, error) {
+func New(upstream, balancing string, logger *zap.Logger) (*Upstream, error) {
 	hostPortSplit := strings.Split(upstream, ":")
 	h := hostPortSplit[0]
 	p := ""
@@ -47,11 +55,12 @@ func New(upstream string, logger *zap.Logger) (*Upstream, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	um := &Upstream{
-		host:    h,
-		port:    p,
-		version: 0,
-		logger:  logger,
-		cancel:  cancel,
+		host:      h,
+		port:      p,
+		version:   0,
+		balancing: balancing,
+		logger:    logger,
+		cancel:    cancel,
 	}
 
 	ips, err := um.RefreshIP(ctx)
@@ -66,7 +75,7 @@ func New(upstream string, logger *zap.Logger) (*Upstream, error) {
 }
 
 // RefreshIP : resolve hostname
-func (u *Upstream) RefreshIP(ctx context.Context) ([]*IP, error) {
+func (u *Upstream) RefreshIP(ctx context.Context) ([]IP, error) {
 	u.mu.Lock()
 	u.version++
 	u.mu.Unlock()
@@ -83,25 +92,31 @@ func (u *Upstream) RefreshIP(ctx context.Context) ([]*IP, error) {
 	})
 
 	csumTexts := make([]string, len(addrs))
-	ips := make([]*IP, len(addrs))
+	ips := make([]IP, len(addrs))
+
+	consistent := consistent.New()
+
 	for i, ia := range addrs {
 		csumTexts[i] = ia.IP.String()
 		address := ia.IP.String()
 		if u.port != "" {
 			address = address + ":" + u.port
 		}
-		ips[i] = &IP{
+		ips[i] = IP{
 			Address: address,
 			version: u.version,
 			busy:    0,
 		}
+		consistent.Add(address)
 	}
+
 	csum := strings.Join(csumTexts, ",")
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if csum != u.csum {
 		u.csum = csum
 		u.ips = ips
+		u.consistent = consistent
 	}
 
 	return ips, nil
@@ -125,13 +140,55 @@ func (u *Upstream) Run(ctx context.Context) {
 }
 
 // GetN :
-func (u *Upstream) GetN(maxIP int) ([]*IP, error) {
+func (u *Upstream) GetN(maxIP int, src net.Addr) ([]IP, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
 	if len(u.ips) < 1 {
 		return nil, errors.New("No upstream hosts")
 	}
+
+	hostPortSplit := strings.Split(src.String(), ":")
+	srcAddr := hostPortSplit[0]
+
+	switch u.balancing {
+	case "fixed":
+		return u.getNByHash(maxIP, u.host)
+	case "iphash":
+		return u.getNByHash(maxIP, srcAddr)
+	default:
+		return u.getNByLC(maxIP)
+	}
+}
+
+func (u *Upstream) getNByHash(maxIP int, key string) ([]IP, error) {
+	if len(u.ips) < maxIP {
+		maxIP = len(u.ips)
+	}
+
+	ips := make([]IP, maxIP)
+
+	res, err := u.consistent.GetN(key, maxIP)
+	if err != nil {
+		return ips, err
+	}
+
+	for i, ip := range res {
+		ips[i] = IP{
+			Address: ip,
+			version: 0, // dummy
+			busy:    0, // dummy
+		}
+		if len(ips) == maxIP {
+			break
+		}
+	}
+
+	return ips, nil
+
+}
+
+func (u *Upstream) getNByLC(maxIP int) ([]IP, error) {
 
 	sort.Slice(u.ips, func(i, j int) bool {
 		if u.ips[i].busy == u.ips[j].busy {
@@ -144,9 +201,9 @@ func (u *Upstream) GetN(maxIP int) ([]*IP, error) {
 		maxIP = len(u.ips)
 	}
 
-	ips := make([]*IP, maxIP)
+	ips := make([]IP, maxIP)
 	for i, ip := range u.ips {
-		ips[i] = &IP{
+		ips[i] = IP{
 			Address: ip.Address,
 			version: ip.version,
 			busy:    0, // dummy
@@ -160,7 +217,7 @@ func (u *Upstream) GetN(maxIP int) ([]*IP, error) {
 }
 
 // Use : Increment counter
-func (u *Upstream) Use(o *IP) {
+func (u *Upstream) Use(o IP) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	for i, ip := range u.ips {
@@ -171,7 +228,7 @@ func (u *Upstream) Use(o *IP) {
 }
 
 // Release : decrement counter
-func (u *Upstream) Release(o *IP) {
+func (u *Upstream) Release(o IP) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	for i, ip := range u.ips {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -156,6 +156,8 @@ func (u *Upstream) GetN(maxIP int, src net.Addr) ([]IP, error) {
 		return u.getNByHash(maxIP, u.host)
 	case "iphash":
 		return u.getNByHash(maxIP, srcAddr)
+	case "remotehash":
+		return u.getNByHash(maxIP, src.String())
 	default:
 		return u.getNByLC(maxIP)
 	}

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -124,8 +124,8 @@ func (u *Upstream) Run(ctx context.Context) {
 	}
 }
 
-// GetAll : wild
-func (u *Upstream) GetAll() ([]*IP, error) {
+// GetN :
+func (u *Upstream) GetN(maxIP int) ([]*IP, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
@@ -140,12 +140,19 @@ func (u *Upstream) GetAll() ([]*IP, error) {
 		return u.ips[i].busy < u.ips[j].busy
 	})
 
-	ips := make([]*IP, len(u.ips))
+	if len(u.ips) < maxIP {
+		maxIP = len(u.ips)
+	}
+
+	ips := make([]*IP, maxIP)
 	for i, ip := range u.ips {
 		ips[i] = &IP{
 			Address: ip.Address,
 			version: ip.version,
 			busy:    0, // dummy
+		}
+		if len(ips) == maxIP {
+			break
 		}
 	}
 


### PR DESCRIPTION
support  --max-connect-retry and  --balancing

```
% ./ppdp -h
Usage:
  ppdp [OPTIONS]

Application Options:
  -v, --version                            Show version
  -l, --listen=                            address to bind (default: 0.0.0.0:3000)
      --upstream=                          upstream server: upstream-server:port
      --proxy-connect-timeout=             timeout of connection to upstream (default: 60s)
      --proxy-protocol                     use proxy-proto for listen
      --dump-tcp=                          Dump TCP. 0 = disable, 1 = src to dest, 2 = both (default: 0)
      --dump-mysql-ping                    Dump mysql ping packet
      --max-connect-retry=                 number of max connection retry (default: 3)
      --balancing=[leastconn|iphash|fixed] balancing mode connection to upstream.  (default: leastconn)

Help Options:
  -h, --help 
```
